### PR TITLE
Check if we're requesting a .css file before running 'compass compile'

### DIFF
--- a/lib/compass.js
+++ b/lib/compass.js
@@ -1,16 +1,20 @@
 var exec = require('child_process').exec;
-
+var path = require('path');
 /**
  * express middleware for serving compiled on-the-fly sass/scss files.
  *
  * @type {Function}
  */
 var compass = module.exports = function(options) {
-    return function(req, res, next) {
-        compass.compile(options, function() {
-            return next();
-        });
-    };
+	return function(req, res, next) {
+		if('.css' == path.extname(req.url)){
+			compass.compile(options, function() {
+				return next();
+			});	
+		} else {
+			return next();
+		}
+	};
 };
 
 /**


### PR DESCRIPTION
To prevent compiling on every request - check for .css in the request url.
